### PR TITLE
drop index column after resetting index

### DIFF
--- a/maltools/io/parsers/readers.py
+++ b/maltools/io/parsers/readers.py
@@ -37,5 +37,5 @@ def read_xml(filepath):
                 dfs.append(df_entry)
 
     # combine dataframes for separate entries into a single dataframe
-    df = pd.concat(dfs).reset_index()
+    df = pd.concat(dfs).reset_index(drop=True)
     return df

--- a/tests/test_io_parsers_readers.py
+++ b/tests/test_io_parsers_readers.py
@@ -84,4 +84,4 @@ def test_read_xml(tmpdir):
     p = tmpdir / "anime.xml"
     p.write_text(EXAMPLE, encoding=None)
     df = maltools.read_xml(p)
-    assert df.shape == (2, 24)
+    assert df.shape == (2, 23)


### PR DESCRIPTION
Function was adding a column for the original index to the front of the DataFrame. This correction removes that column.